### PR TITLE
Almond's behavior differs from RequireJS when defining the same thing multiple times

### DIFF
--- a/almond.js
+++ b/almond.js
@@ -17,6 +17,11 @@ var requirejs, require, define;
         aps = [].slice,
         main, req;
 
+    // If there's an existing AMD loader - we're superflous.
+    if (typeof define !== 'undefined') {
+        return;
+    }
+
     /**
      * Given a relative module name, like ./something, normalize it to
      * a real name that can be mapped to a path.
@@ -286,6 +291,15 @@ var requirejs, require, define;
     };
 
     /**
+     * Removes the definition of a module
+     */
+    req.undef = function(name) {
+        delete waiting[name];
+        delete defined[name];
+        delete defining[name];
+    };
+
+    /**
      * Just drops the config on the floor, but returns req in case
      * the config return value is used.
      */
@@ -305,7 +319,10 @@ var requirejs, require, define;
             deps = [];
         }
 
-        waiting[name] = [name, deps, callback];
+        // Don't override existing modules - i.e. behave just as RequireJS.
+        if(!waiting[name] && !defined[name]) {
+            waiting[name] = [name, deps, callback];
+        }
     };
 
     define.amd = {


### PR DESCRIPTION
## Problem

RequireJS favors the first definition of a module while Almond favors the last one, this discrepancy could introduce unexpected bugs.
## With almond.js

``` javascript
// almond.js source

define('test', function() {
  return function() {
    return 'I am the FIRST version of the module';
  }
});

define('test', function() {
  return function() {
    return 'I am the SECOND version of the module';
  }
});

require([ 'test' ], function(test) {
  console.log(test());
  // Will log 'I am the SECOND version of the module'
}); 
```
## With require.js

``` javascript
// require.js source

define('test', function() {
  return function() {
    return 'I am the FIRST version of the module';
  }
});

define('test', function() {
  return function() {
    return 'I am the SECOND version of the module';
  }
});

require([ 'test' ], function(test) {
  console.log(test());
  // Will log 'I am the FIRST version of the module'
}); 
```
## Proposed solution

I'd prefer that `almond.js` had the `require.js` behavior. One use case for this is to override templates with custom ones before loading your Javascript app, and have the first definition of a module override the latter. Reading the [RequireJS docs](http://requirejs.org/docs/api.html#undef) seem to favor this due to to the `undef` method.
