### PR TITLE
Make external relative paths working again

### DIFF
--- a/almond.js
+++ b/almond.js
@@ -61,7 +61,7 @@ var requirejs, require, define;
                             //no path mapping for a path starting with '..'.
                             //This can still fail, but catches the most reasonable
                             //uses of ..
-                            return true;
+                            break;
                         } else if (i > 0) {
                             name.splice(i - 1, 2);
                             i -= 2;

--- a/tests/relativePaths/relativePaths.html
+++ b/tests/relativePaths/relativePaths.html
@@ -26,10 +26,17 @@
             };
         });
 
-        define('main', ['./foo/b'], function(v){
+        define('../../ext',[], function(){
+            return {
+                name: 'ext'
+            };
+        });
+
+        define('main', ['./foo/b', '../../ext'], function(v, e){
             return {
                 name: 'main',
-                fooB: v
+                fooB: v,
+                ext: e
             };
         });
 
@@ -42,6 +49,7 @@
                         t.is('foo/b', main.fooB.name);
                         t.is('foo/bar/c', main.fooB.barC.name);
                         t.is('fu/a', main.fooB.barC.fuA.name);
+                        t.is('ext', main.ext.name);
                     }
                 ]
             );


### PR DESCRIPTION
You can not depend currently on a relative module using too many parent notation.
##### For example:

``` javascript
define("something", ["../../dependency"], ...);
```
##### Explanation:

The related iteration was replaced by an `each` call in commit [c9657f2](https://github.com/jrburke/almond/commit/c9657f2#L1L50) which was reverted later in commit [ce262cf](https://github.com/jrburke/almond/commit/ce262cf#L0L61). In first commit the `break` statement was rewritten to `return true` but in the latter it is not reverted to `break`.
##### Pull Request:

The bug is fixed and the relativePaths test suite is updated to test the problematic case.
