### PR TITLE
Update tests/defineDouble/defineDouble.html

### DIFF
--- a/tests/defineDouble/defineDouble.html
+++ b/tests/defineDouble/defineDouble.html
@@ -26,7 +26,7 @@
                 bCount += 1;
             });
 
-            require(['a', 'b'], function () {
+            require(['a', 'b'], function () {
                 doh.register(
                     'defineDouble',
                     [


### PR DESCRIPTION
Fixes a char encoding error causing defineDouble test to fail
