### PR TITLE
Fix for use of AMD define without name/dependencies

### DIFF
--- a/almond.js
+++ b/almond.js
@@ -377,7 +377,7 @@ var requirejs, require, define;
     define = function (name, deps, callback) {
 
         //This module may not have dependencies
-        if (!deps.splice) {
+        if (!deps || !deps.splice) {
             //deps is not an array, so probably means
             //an object literal or factory function for
             //the value. Adjust args.


### PR DESCRIPTION
Spin.js 
(https://github.com/fgnass/spin.js/blob/gh-pages/spin.js#L316)

uses define without any dependencies, so deps becomes undefined. This 
usage appears valid based on the AMD definition: 

http://wiki.commonjs.org/wiki/Modules/AsynchronousDefinition

While spin.js' use of define is relatively not useful, it's valid.
This change will accommodate modules that work in this manner.
