### PR TITLE
Method for checking whether a module can be require()'d

### DIFF
--- a/almond.js
+++ b/almond.js
@@ -399,6 +399,10 @@ var requirejs, require, define;
         }
     };
 
+    define.isDefined = function (name) {
+        return hasProp(defined, name) || hasProp(waiting, name);
+    };
+
     define.amd = {
         jQuery: true
     };

--- a/tests/all.js
+++ b/tests/all.js
@@ -27,3 +27,4 @@ doh.registerUrl("hasOwnPropertyTests", "../hasOwnProperty/hasOwnProperty.html");
 doh.registerUrl("firstDefine", "../firstDefine/firstDefine.html");
 doh.registerUrl("topRelativeRequire", "../topRelativeRequire/topRelativeRequire.html");
 doh.registerUrl("configDeps", "../configDeps/configDeps.html");
+doh.registerUrl("isDefined", "../isDefined/isDefined.html");

--- a/tests/isDefined/isDefined.html
+++ b/tests/isDefined/isDefined.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>almond: isDefined test</title>
+    <script src="../doh/runner.js"></script>
+    <script src="../doh/_browserRunner.js"></script>
+    <script src="../../almond.js"></script>
+    <script>
+        define('a', function () {});
+        define('b', function () {});
+        require(['a'], function () {
+            doh.register(
+                'isDefined',
+                [
+                    function isDefined(t){
+                        t.is(true, define.isDefined('a'));
+                        t.is(true, define.isDefined('b'));
+                        t.is(false, define.isDefined('c'));
+                    }
+                ]
+            );
+            doh.run();
+        });
+    </script>
+</head>
+<body>
+    <h1>almond: isDefined test</h1>
+    <p>A method which reports whether a module has been defined</p>
+    <p>Check console for messages</p>
+</body>
+</html>


### PR DESCRIPTION
It can be very useful to know if a module has been defined (or is waiting to be evaluated), but the information about this isn't exposed by almond. The only other method I've found is essentially:

``` javascript
function isDefined(name) {
  try {
    require(name);
    return true;
  } catch (e) {
    return false;
  }
}
```

...which is obviously not-so-good.

This PR exposes the information via `define.isDefined()`. I'm not sure if that's the exactly correct nomenclature, but hopefully the idea is sound.

_I haven't done the CLA thing, since I thought I'd wait for feedback first._
