### PR TITLE
Adding repository section to package.json to suppress warning from NPM.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
     "version": "0.2.5",
     "homepage": "http://github.com/jrburke/almond",
     "author": "James Burke <jrburke@gmail.com> (http://github.com/jrburke)",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/jrburke/almond.git"
+    },
     "licenses": [
         {
             "type": "BSD",


### PR DESCRIPTION
NPM emits a warning when the repository field is not defined in the `package.json` file:

```
npm WARN package.json almond@0.2.5 No repository field.
```

This pull request adds the repository field. :-)
