### PR TITLE
Safe-check if no dependency is given

### DIFF
--- a/almond.js
+++ b/almond.js
@@ -386,7 +386,7 @@ var requirejs, require, define;
     define = function (name, deps, callback) {
 
         //This module may not have dependencies
-        if (!deps.splice) {
+        if (!deps || !deps.splice) {
             //deps is not an array, so probably means
             //an object literal or factory function for
             //the value. Adjust args.


### PR DESCRIPTION
Hey guys,

Using Almond on an application, I had to integrate LeafletJS, but an error occurred at load.

You can check https://github.com/Leaflet/Leaflet/blob/master/src/Leaflet.js line 13, `define` is called just with a module name. As they was no deps, the code was failing, I just added a check and it now works.
