### PR TITLE
Prevent "Uncaught TypeError: Cannot read property 'splice' of undefined"...

### DIFF
--- a/almond.js
+++ b/almond.js
@@ -386,7 +386,7 @@ var requirejs, require, define;
     define = function (name, deps, callback) {
 
         //This module may not have dependencies
-        if (!deps.splice) {
+        if (typeof deps !== 'undefined' && !deps.splice) {
             //deps is not an array, so probably means
             //an object literal or factory function for
             //the value. Adjust args.


### PR DESCRIPTION
Hello,
While working both w/ Almond and [JavaScript-Templates](https://github.com/blueimp/JavaScript-Templates) libraries I got an error which is listed here in [Common errors](https://github.com/jrburke/almond#deps-is-undefined) part:

`Uncaught TypeError: Cannot read property 'splice' of undefined`

In README file I read that the root of the problem is:

> This is usually a sign that the tool you used to combine all the modules together did not properly name an anonymous AMD module.

But... RequireJs allows to pass a single callback argument when define anonymous module See [official site](http://requirejs.org/docs/api.html#deffunc) for details. So looks like the a module defined correctly, right?

I propose to fix/suppress the error throwing and breaking the script(s) by this simple changeset.

FYI, I first referred to the author of [template library](https://github.com/blueimp/JavaScript-Templates/pull/28) he didn't accept my pull request. Also, I see other libraries may potentially violate the rule w/ passing at least name & callback. For ex., see [hammer.js.](https://github.com/EightMedia/hammer.js/blob/master/dist/hammer.js):

```
// Based off Lo-Dash's excellent UMD wrapper (slightly modified) - https://github.com/bestiejs/lodash/blob/master/lodash.js#L5515-L5543
// some AMD build optimizers, like r.js, check for specific condition patterns like the following:
if(typeof define == 'function' && typeof define.amd == 'object' && define.amd) {
    // Expose Hammer to the global object even when an AMD loader is present in
    // case Hammer was injected by a third-party script and not intended to be
    // loaded as a module.
    window.Hammer = Hammer;

    // define as an anonymous module
    define(function() {
        return Hammer;
    });
}
```

I would be grateful if the .slice error will be resolved.
Thanks,
Anna.
