### PR TITLE
expose defined as define.defined

### DIFF
--- a/almond.js
+++ b/almond.js
@@ -399,6 +399,8 @@ var requirejs, require, define;
         }
     };
 
+    define.defined = defined;
+
     define.amd = {
         jQuery: true
     };


### PR DESCRIPTION
This allows frameworks to check if a module is
defined or not. An example use case is to provide
default objects to the app when the app developer
didn't define their own.

Open to a different name like, define.registry.

Our exact use case is in ember. If the app
developer creates a module at
'controllers/application_controller' then the app will
use it, but if none is found it will create a default
object. Our module resolver currently uses a try/catch
but explicitly checking a registry would be preferred.

https://github.com/rpflorence/ember-app-kit/blob/almond/vendor/resolver.js#L50-L75
