### PR TITLE
expose defined as requirejs._defined

### DIFF
--- a/almond.js
+++ b/almond.js
@@ -383,6 +383,11 @@ var requirejs, require, define;
         return req;
     };
 
+    /**
+     * Expose module registry for debugging and tooling
+     */
+    requirejs._defined = defined;
+
     define = function (name, deps, callback) {
 
         //This module may not have dependencies


### PR DESCRIPTION
use cases:
- debugging
- tooling
- allows frameworks to check if a module is
  defined or not before providing a default module
