### PR TITLE
Add error.code = 'MODULE_NOT_FOUND' on exceptions

### DIFF
--- a/almond.js
+++ b/almond.js
@@ -167,7 +167,9 @@ var requirejs, require, define;
         }
 
         if (!hasProp(defined, name) && !hasProp(defining, name)) {
-            throw new Error('No ' + name);
+            var error = new Error('No ' + name);
+            error.code = 'MODULE_NOT_FOUND';
+            throw error;
         }
         return defined[name];
     }
@@ -293,7 +295,9 @@ var requirejs, require, define;
                     map.p.load(map.n, makeRequire(relName, true), makeLoad(depName), {});
                     args[i] = defined[depName];
                 } else {
-                    throw new Error(name + ' missing ' + depName);
+                    var error = new Error(name + ' missing ' + depName);
+                    error.code = 'MODULE_NOT_FOUND';
+                    throw error;
                 }
             }
 


### PR DESCRIPTION
This is analogous to Node.

---

Here is the use case: I'm writing a build tool for Ember apps, which makes all modules available synchronously, in a single compiled `app.js` blob. When the Ember app gets loaded in the browser, it would be very useful to be able to detect if certain modules are available, with a function like so:

``` js
  // Return module or null
  function tryRequire(deps) {
    try {
      return require(deps, null, null, true /* force sync */);
    } catch (err) {
      if (err.code === 'MODULE_NOT_FOUND')
        return null;
      throw err;
    }
  }
```

But I don't want to catch errors indiscriminately, and regex matching on the error message seems like a bad idea. So I'd like to check `err.code`.

Node has a similar `.code` property:

``` js
try { require('asdf') } catch (e) { console.log(e.code) }
// => MODULE_NOT_FOUND
```

Is this a bad idea altogether?

I'm also not entirely sure if both errors should get the same error code (see diff) -- I don't know RequireJS and almond well enough.

Let me know what you think.
