### PR TITLE
Allow module definitions with no callback function

### DIFF
--- a/almond.js
+++ b/almond.js
@@ -265,7 +265,7 @@ var requirejs, require, define;
         relName = relName || name;
 
         //Call the callback to define the module, if necessary.
-        if (typeof callback === 'function') {
+        if (typeof callback === 'function' || typeof callback === 'undefined') {
 
             //Pull out the defined dependencies and pass the ordered
             //values to the callback.
@@ -297,7 +297,9 @@ var requirejs, require, define;
                 }
             }
 
-            ret = callback.apply(defined[name], args);
+            ret = typeof callback !== 'undefined'
+                ? callback.apply(defined[name], args)
+                : null;
 
             if (name) {
                 //If setting exports via "module" is in play,


### PR DESCRIPTION
requirejs allows you to create a module definition with no "callback" function. An example of why you may want to do this is to add your own custom validators into a base validation framework (e.g. knockout.validation). You may define your own module "knockout/validation" as follows:

```
define("knockout/validation", ["knockout", "knockout.validation", "knockout.validation.customValidators"]);
```

In this example, the `knockout.validation` module does not return anything (i.e. it does not define a module, it extends the `knockout` module); similarly, the `knockout.validation.customValidators` does not define a module.

requirejs allows for this type of definition, and correctly loads the dependencies when the `knockout/validation` module is required.

Almond will only load the dependencies when there is a "callback" function provided; otherwise it treats the definition as a simple object definition. To cater for this, we would need to change the object definition as follows:

```
var noop = function() {};
define("knockout/validation", ["knockout", "knockout.validation", "knockout.validation.customValidators"], noop);
```

The attached pull request allows almond to correctly define a module even when no callback function is supplied.
