### PR TITLE
Adds license comment annotation

### DIFF
--- a/almond.js
+++ b/almond.js
@@ -1,5 +1,5 @@
 /**
- * almond 0.2.7 Copyright (c) 2011-2012, The Dojo Foundation All Rights Reserved.
+ * @license almond 0.2.7 Copyright (c) 2011-2012, The Dojo Foundation All Rights Reserved.
  * Available via the MIT or new BSD license.
  * see: http://github.com/jrburke/almond for details
  */


### PR DESCRIPTION
Allows minifiers such as Closure or Uglify to preserve the copyright and license information.

I was preparing a site for production and ensuring proper license information was included for all libraries I used in my work, and found that the almond license was missing. This (tiny) fix ensures proper attribution by anyone using the Closure or UglifyJS compilers with default settings.

Thanks for your great work on Almond :+1: 
