### PR TITLE
Find external dependencies

### DIFF
--- a/almond.js
+++ b/almond.js
@@ -301,7 +301,18 @@ var requirejs, require, define;
                     map.p.load(map.n, makeRequire(relName, true), makeLoad(depName), {});
                     args[i] = defined[depName];
                 } else {
-                    throw new Error(name + ' missing ' + depName);
+	                // Try to use requirejs
+	                if ((typeof window.requirejs === 'function') && window.requirejs.defined(depName)) {
+		                args[i] = window.requirejs(depName);
+	                }
+	                if (args[i] === undefined) {
+		                if (window[depName] !== undefined) {
+			                // Use the global
+			                args[i] = window[depName];
+		                } else {
+			                throw new Error(name + ' missing ' + depName);
+		                }
+	                }
                 }
             }
 


### PR DESCRIPTION
When almond can’t find a dependency, see if we can find it using requirejs or in the global scope before throwing an error.

This allows one to compile a project that has some external dependencies, and still use it with or without using requirejs. For example, building a jquery plugin module.
