### PR TITLE
Added require.defined() to replicate require.js

### DIFF
--- a/almond.js
+++ b/almond.js
@@ -397,7 +397,14 @@ var requirejs, require, define;
     /**
      * Expose module registry for debugging and tooling
      */
-    requirejs._defined = defined;
+    req._defined = defined;
+
+    /**
+     * Expose the defined() function with the same signature as require.js
+     */
+    req.defined = function (name) {
+        return hasProp(defined, name);
+    };
 
     define = function (name, deps, callback) {
 


### PR DESCRIPTION
I use the (undocumented) RequireJS `require.defined()` function in my web app to dynamically check if the current view has any code to run.  For example, I have AMD modules that are named like `views/foo`, and my app.js checks to see if `views/foo` exists.  If so, it calls `.init()` on that module.

For example:

```
if (require.defined('views/' + viewName)) {
    require('views/' + viewName).init();
}
```

The `require.defined()` function isn't exposed in the almond wrapper, just `require._defined` (a map of views).

This PR adds a simple `require.defined()` function to match requirejs's.
