### PR TITLE
Always remove single dots from relative paths

### DIFF
--- a/almond.js
+++ b/almond.js
@@ -66,7 +66,12 @@ var requirejs, require, define;
                     if (part === ".") {
                         name.splice(i, 1);
                         i -= 1;
-                    } else if (part === "..") {
+                    }
+                }
+
+                for (i = 0; i < name.length; i += 1) {
+                    part = name[i];
+                    if (part === "..") {
                         if (i === 1 && (name[2] === '..' || name[0] === '..')) {
                             //End of the line. Keep at least one non-dot
                             //path segment at the front so it can be mapped

--- a/tests/relativePaths/relativePaths.html
+++ b/tests/relativePaths/relativePaths.html
@@ -26,9 +26,16 @@
             };
         });
 
-        define('../../ext',[], function(){
+        define('../../ext',['./extb'], function(e){
             return {
-                name: 'ext'
+                name: 'ext',
+                extB: e
+            };
+        });
+
+        define('../../extb',[], function(){
+            return {
+                name: 'extb'
             };
         });
 
@@ -50,6 +57,7 @@
                         t.is('foo/bar/c', main.fooB.barC.name);
                         t.is('fu/a', main.fooB.barC.fuA.name);
                         t.is('ext', main.ext.name);
+                        t.is('extb', main.ext.extB.name);
                     }
                 ]
             );


### PR DESCRIPTION
Let's assume the following directory structure and files:
```
/
- plugin/
  - extA.js
  - extB.js
- lib/
  - core/
    - main.js
    - foo.js
```
main.js:
```js
require(['../../plugin/extA', 'foo'], function (A, foo) {
    //...
});
```

extA.js:
```js
define(['./extB'], function (B) {
    //...
});
```

extB.js:
```js
define( function () {
    //...
});
```

The `baseUrl` in the build configuration was set to `lib/core/`.

This scenario will fail to run in current implementation - because of the [line 77](https://github.com/gregpabian/almond/blob/master/almond.js#L77) that breaks the normalization Almond will try to load `../.././extB` instead of `../../extB`.