### PR TITLE
add support to Ember resolver dependency on requirejs._eak_seen

### DIFF
--- a/almond.js
+++ b/almond.js
@@ -13,6 +13,7 @@ var requirejs, require, define;
     var main, req, makeMap, handlers,
         defined = {},
         waiting = {},
+        seen = {},
         config = {},
         defining = {},
         hasOwn = Object.prototype.hasOwnProperty,
@@ -406,8 +407,10 @@ var requirejs, require, define;
      * Expose module registry for debugging and tooling
      */
     requirejs._defined = defined;
+    requirejs._eak_seen = seen;
 
     define = function (name, deps, callback) {
+        seen[name] = true;
 
         //This module may not have dependencies
         if (!deps.splice) {


### PR DESCRIPTION
Hi @jrburke,

`requirejs._eak_seen` option is used ONLY for Ember-CLI fashion application. In the current [Ember-CLI](https://github.com/stefanpenner/ember-cli), it uses custom AMD module loader [loader.js](https://github.com/stefanpenner/ember-cli/blob/14b488f62534853f6f1a67b683db25f72ffd9b5d/tests/fixtures/addon/simple/bower.json#L9). It essentially does the same thing that Almond is doing. Lightweight AMD module loader. 

The only difference that Loader.js is used inside Ember-Resolver so that It requires a custom `option` property called [`_eak_seen`](https://github.com/stefanpenner/loader.js/blob/master/loader.js#L142). Used ONLY inside Ember application to determine that module is loaded, ready to be DI. 

Could we add the support for this property,  `_eak_seen`. I have been used custom version for a while in my project [ember-rocks](https://github.com/mattma/ember-rocks/blob/master/src/skeletons/core/client/assets/vendors/almond.js#L13) and have to manually update myself each time when you release the new version. I want to take advantage of [bower.json](https://github.com/mattma/ember-rocks/blob/master/src/skeletons/core/bower.json#L13) if possible so that I do not need to include a plain `almond.js` file. 

Hopefully that you could add this property to support Ember.js Application. Much appreciated. 
