### PR TITLE
README Minor Markdown format issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#almond
+# almond
 
 A replacement [AMD](https://github.com/amdjs/amdjs-api/wiki/AMD) loader for
 [RequireJS](http://requirejs.org). It provides a minimal AMD API footprint that includes [loader plugin](http://requirejs.org/docs/plugins.html) support. Only useful for built/bundled AMD modules, does not do dynamic loading.


### PR DESCRIPTION
Fix markdown header formatting by adding space between # and "almond"

Before:
#almond

After:
# almond