### PR TITLE
Update license link in almond.js

### DIFF
--- a/almond.js
+++ b/almond.js
@@ -1,6 +1,6 @@
 /**
  * @license almond 0.3.3 Copyright jQuery Foundation and other contributors.
- * Released under MIT license, http://github.com/requirejs/almond/LICENSE
+ * Released under MIT license, https://github.com/requirejs/almond/blob/master/LICENSE
  */
 //Going sloppy to avoid 'use strict' string cost, but strict practices should
 //be followed.


### PR DESCRIPTION
The 2016 github link no longer works, and some legal minds seem to be of the opinion that this means any redistributor of this code is distributing it without the license text or link.