### PR TITLE
Fix LICENSE URL in the header of almond.js

### DIFF
--- a/almond.js
+++ b/almond.js
@@ -1,6 +1,6 @@
 /**
  * @license almond 0.3.3 Copyright jQuery Foundation and other contributors.
- * Released under MIT license, http://github.com/requirejs/almond/LICENSE
+ * Released under MIT license, https://github.com/oracle/almond/blob/master/LICENSE
  */
 //Going sloppy to avoid 'use strict' string cost, but strict practices should
 //be followed.


### PR DESCRIPTION
Fixing the URL to the `LICENSE` file so that it works correctly.

Signed-off-by: Avi Miller <avi.miller@oracle.com>